### PR TITLE
Do not use deployment if env beta is not passed

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -5,7 +5,7 @@ const { config: webpackConfig, plugins } = config({
   debug: true,
   https: true,
   useFileHash: false,
-  deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  ...(process.env.BETA && { deployment: 'beta/apps' }),
 });
 
 plugins.push(

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -4,7 +4,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin;
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
-  deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  ...(process.env.BETA && { deployment: 'beta/apps' }),
 });
 
 plugins.push(


### PR DESCRIPTION
### No beta paths

When running build in production mode, the beta is not included. This is caused by expecting env var beta, but this variable doesn't really have to be there. This PR fixes such issue, by exploding deployment config only if beta env var is present.