### PR TITLE
Add DevEntry to properly enable redux logger.

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -13,6 +13,9 @@ plugins.push(
     {
       root: resolve(__dirname, '../'),
       useFileHash: false,
+      exposes: {
+        './RootApp': resolve(__dirname, '../src/DevEntry'),
+      },
     }
   )
 );

--- a/src/DevEntry.js
+++ b/src/DevEntry.js
@@ -4,13 +4,14 @@ import { Provider } from 'react-redux';
 import { init } from './store';
 import App from './App';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
+import logger from 'redux-logger';
 
-const AppEntry = () => (
-  <Provider store={init().getStore()}>
+const DevEntry = () => (
+  <Provider store={init(logger).getStore()}>
     <Router basename={getBaseName(window.location.pathname)}>
       <App />
     </Router>
   </Provider>
 );
 
-export default AppEntry;
+export default DevEntry;

--- a/src/bootstrap-dev.js
+++ b/src/bootstrap-dev.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import AppEntry from './AppEntry';
-import logger from 'redux-logger';
 
 const root = document.getElementById('root');
 
-ReactDOM.render(<AppEntry logger={logger} />, root, () =>
+ReactDOM.render(<AppEntry />, root, () =>
   root.setAttribute('data-ouia-safe', true)
 );


### PR DESCRIPTION
The redux logger is triggered in dev env only when using old chrome. By adding the `DevEntry.js` file, we can add dev specific code which won't be bundled into the production version.