### PR TITLE
Use .env file when present for npm run start and start:beta

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+# Set this variable when using prod, else it will use stage
+# USE_PROD=true
+
+# Set this variable when using beta, else it uses stable
+# BETA=true
+
+# Set this variable to use a specific routes file
+# ROUTES_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ yarn-error.log*
 
 .DS_Store
 coverage
+
+.env

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ sudo npm run patch:hosts
 
 Update `config/dev.webpack.config.js` according to your application URL. [Read more](https://github.com/RedHatInsights/frontend-components/tree/master/packages/config#useproxy).
 
+### Managing environmental variables
+
+For development purposes, it's sometimes required to load different environment variables.
+For example, to test in prod-beta you could set `USE_PROD=true BETA=true npm run start`.
+
+An [.env.sample](./.env.sample) file is provided with sample config.
+You can copy it to `.env` and edit as required to provide an easier way to set all your required environment variables.
+
 ### Testing
 
 `npm run verify` will run `npm run lint` (eslint) and `npm test` (Jest)

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -2,13 +2,20 @@ const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const commonPlugins = require('./plugins');
 
+const env = () => {
+  const type = process.env.USE_PROD ? 'prod' : 'stage';
+  const stable = process.env.BETA ? 'beta' : 'stable';
+  return `${type}-${stable}`;
+};
+
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
   useProxy: true,
   appUrl: process.env.BETA ? '/beta/staging/starter' : '/staging/starter',
-  env: process.env.BETA ? 'stage-beta' : 'stage-stable',
+  env: env(),
+  routesPath: process.env.ROUTES_PATH
 });
 plugins.push(...commonPlugins);
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -15,7 +15,7 @@ const { config: webpackConfig, plugins } = config({
   useProxy: true,
   appUrl: process.env.BETA ? '/beta/staging/starter' : '/staging/starter',
   env: env(),
-  routesPath: process.env.ROUTES_PATH
+  routesPath: process.env.ROUTES_PATH,
 });
 plugins.push(...commonPlugins);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@testing-library/react": "^12.1.2",
         "babel-jest": "27.0.5",
         "babel-plugin-transform-imports": "^2.0.0",
+        "env-cmd": "^10.1.0",
         "eslint": "7.29.0",
         "eslint-loader": "4.0.2",
         "identity-obj-proxy": "3.0.0",
@@ -7710,6 +7711,31 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "node_modules/env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "bin": {
+        "env-cmd": "bin/env-cmd.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/env-cmd/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/envinfo": {
       "version": "7.8.1",
@@ -24174,6 +24200,24 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dev": true,
+      "requires": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        }
+      }
     },
     "envinfo": {
       "version": "7.8.1",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "nightly": "npm run deploy",
     "patch:hosts": "fec patch-etc-hosts",
-    "start": "webpack serve --config config/dev.webpack.config.js",
-    "start:beta": "BETA=true npm start",
+    "start": "env-cmd --no-override --silent webpack serve --config config/dev.webpack.config.js",
+    "start:beta": "BETA=true env-cmd --no-override --silent npm start",
     "test": "jest",
     "verify": "npm-run-all build lint test"
   },
@@ -48,6 +48,7 @@
     "@testing-library/react": "^12.1.2",
     "babel-jest": "27.0.5",
     "babel-plugin-transform-imports": "^2.0.0",
+    "env-cmd": "^10.1.0",
     "eslint": "7.29.0",
     "eslint-loader": "4.0.2",
     "identity-obj-proxy": "3.0.0",


### PR DESCRIPTION
This is a small idea I had to make it easier to switch between environment/configurations. As I find myself trying cycling the different environments and from using the environment backend or my local backend. 

I sometimes need to use different routes and this is way easier than digging into the files and updating them or manually defining.
Figured it would be easier to have an `.env` to setup this kind of stuff than updating the `scripts` with the multiple combinations.