### PR TITLE
Add API to frontend spec

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -9,6 +9,9 @@ objects:
     metadata:
       name: frontend-starter-app
     spec:
+      API:
+        versions:
+          - v1
       envName: ${ENV_NAME}
       title: Starter App
       deploymentRepo: https://github.com/RedHatInsights/frontend-starter-app


### PR DESCRIPTION
Required field for frontend resource. Causing pipeline to fail

```
[2023-08-11 11:28:27] [ERROR] [openshift_base.py:_realize_resource_data:686] - [crcs02ue1/frontends] [https://api.crcs02ue1.urby.p1.openshiftapps.com:6443]: The Frontend "frontend-starter-app" is invalid: spec.API: Required value
 (error details: https://github.com/RedHatInsights/frontend-starter-app/blob/00077dbf8972011e9a2a30fdec74b5415269175a/deploy/frontend.yaml)
```