### PR TITLE
Fix malformed frontend.yaml for FEO

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -11,11 +11,12 @@ objects:
     spec:
       feoConfigEnabled: true
       serviceTiles:
-        - section: automation
+        - id: starter-link
+          section: automation
           group: ansible
           title: Starter app FEO integration testing tile
           href: /staging/starter
-          description: This tile will not show in production and exists only for integration etsting purposes
+          description: This tile will not show in production and exists only for integration testing purposes
           icon: AnsibleIcon
       searchEntries:
         - id: "starter"


### PR DESCRIPTION
frontend-starter-app is failing to deploy in stage. Looking at the logs it appears our yaml is malformed:

```bash
The Frontend "frontend-starter-app" is invalid: spec.serviceTiles[0].id: Required value
 (error details: https://github.com/RedHatInsights/frontend-starter-app/blob/master/deploy/frontend.yaml)
```

@Hyperkid123 it would probably be good to expose a CLI util that would validate the yaml from a FEO perspective 🤔 